### PR TITLE
disable all warnings unless M3U8_DEBUG env-var is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ install
 example
 -------
 
-``` js
+```js
 var m3u8 = require('@chovy/m3u8');
 var fs   = require('fs');
 
@@ -34,7 +34,7 @@ parser.on('m3u', function(m3u) {
 All items and the m3u object have `toString()` methods for conversion to m3u8.
 Attributes and properties have getter/setters on m3u and item objects:
 
-```
+```js
 parser.on('item', function(item) {
   var duration = item.get('bandwidth');
   item.set('uri', 'http://example.com/' + item.get('uri'));
@@ -42,7 +42,8 @@ parser.on('item', function(item) {
 ```
 
 The M3U and Item objects are available on m3u8:
-```
+
+```js
 var m3u8 = require('@chovy/m3u8');
 
 var m3u = m3u8.M3U.create();
@@ -53,3 +54,5 @@ m3u.addPlaylistItem({
 ```
 
 See tests for more usage patterns.
+
+You can set `M3U8_DEBUG` environment variable to get debugging warnings about unkown attributes.

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ m3u.addPlaylistItem({
 
 See tests for more usage patterns.
 
-You can set `M3U8_DEBUG` environment variable to get debugging warnings about unkown attributes.
+You can set `M3U8_DEBUG` environment variable to get debugging warnings about unknown attributes.

--- a/m3u/AttributeList.js
+++ b/m3u/AttributeList.js
@@ -122,7 +122,9 @@ var parse = {
         }
     },
     'unknown': function parseUnknown(value, key) {
-        console.error('Handling value:', value, ' for unknown key:', key);
+        if (process.env.M3U8_DEBUG){
+            console.error('Handling value:', value, ' for unknown key:', key);
+        }
         return value;
     }
 };


### PR DESCRIPTION
I was getting a bunch of other warnings with app-store m3u8 files.

```
Handling value: "2"  for unknown key: channels
Handling value: 636239  for unknown key: _avg-bandwidth
```

This disables  all attribute warnings unless  `process.env.M3U8_DEBUG` is explicitly set.